### PR TITLE
fix for #964

### DIFF
--- a/scripts/soil_samples/doi_10.5281_zenodo.6566752.R
+++ b/scripts/soil_samples/doi_10.5281_zenodo.6566752.R
@@ -2,18 +2,17 @@
 # license: GPL (>=3)
 
 ## ISSUES
+
 # Chilimo litter-bag decomposition experiment, litter AWEN chemistry, soil
 # temperature loggers, and monthly weather normals not processed: different
 # observational unit (small elevation-gradient trial, not the 98-SU national grid).
 # Left for a future contribution.
-# biome, stoniness_pct, SOC_stock_tha, litter_C_stock_tha not in terminag (only the
-# concentration soil_SOC, %, is standardized): kept under a reasonable name so they
-# are flagged by the vocabulary check and can be considered for terminag.
+
 # Source "LAT"/"LON" columns are swapped (LAT values fall in Ethiopia's longitude
 # range 34-42, LON in its latitude range 5-14.5); corrected here.
-# adm1 "Benishangul_Gumuz" -> "Benishangul-Gumuz"; "Dembi Dolo" (a town, not a
-# region) -> "Oromia".
+# adm1 "Benishangul_Gumuz" -> "Benishangul-Gumuz"; "Dembi Dolo" (a town, not a  region) -> "Oromia".
 # location_id values are lab/field codes (e.g. "T-2"), not place names.
+
 # SU O-348 has 2 litter measurements in the source with no replicate id; averaged.
 # One extreme soil_bd (2.53 g/cm3, site AM-62, 20-30cm) kept as-is from source.
 
@@ -62,14 +61,6 @@ the same SUs."
 	f2 <- ff[basename(ff) == "OC%20_PSA_12.2.2018.xlsx"]
 	r2 <- carobiner::read.excel(f2, sheet="Sheet2", skip=2, fix_names=TRUE, lower=TRUE)
 
-## do not rename columns like this. Too risky
-## I used "fix_names" above to get more standard names (no spaces or special characters)
-#	colnames(r2) <- c("lab_no", "field_code", "depth_range", "net_sample_weight_g",
-#		"water_loss_105C", "weight_gt2mm_g", "weight_lt2mm_g", "OC_WB_pct",
-#		"coarse_fragment_pct", " =
-# lab.n, field.code, depth.cm, net.sample.weight.at.lab.g, water.lost.at.105.0c, weight.of.2mm.sample.g,
-# weight.of..2mm.sample.g, x.pct.oc.w.b.method, course.fragemet.pct, sand, silt, clay, textural.class"
-
 	f3 <- ff[basename(ff) == "Litter_Ethiopia_25.1.2018.xlsx"]
 	r3 <- carobiner::read.excel(f3)
 
@@ -88,10 +79,9 @@ the same SUs."
 		depth_bottom = as.numeric(depth[,2]),
 		soil_SOC = r1$OC_adj,
 		soil_bd = r1$BDfe,
-		biome = r1$BiomeSimplified,
-## not in terminag
-		soil_stoniness = r1$StoninessVSFAST, #%
-		soil_SOC_stock = r1$SOCfe_stoniness #_tha
+		#biome = r1$BiomeSimplified,
+		soil_stones = r1$StoninessVSFAST, #%
+		soil_C_stock = r1$SOCfe_stoniness * 10  #t ha to g/m2
 	)
 
 	d1$adm1[d1$adm1 == "Dembi Dolo"] <- "Oromia"
@@ -110,10 +100,15 @@ the same SUs."
 ## drop the extra copy, it is unused by the merge below either way,
 	d2 <- unique(d2)
 
+	d3 <- data.frame(
+		location_id = gsub(" +", "", trimws(r3$FieldCode)),
+		soil_C_litter = LitterCStock_tha
+	}
+
 ## SU O-348 has 2 litter measurements with no replicate id (see ISSUES); average them
 ## to one value per SU so the merge below doesn't fan out the unrelated SOC depth rows
-	r3$location_id <- gsub(" +", "", trimws(r3$FieldCode))
-	d3 <- aggregate(cbind(LitterCStock_tha) ~ location_id, data=r3, FUN=mean, na.rm=TRUE)
+	d3 <- aggregate(soil_C_litter ~ location_id, data=d3, FUN=mean, na.rm=TRUE)
+
 
 	d <- merge(d1, d2, by=c("location_id", "depth_range"), all.x=TRUE)
 	d <- merge(d, d3, by="location_id", all.x=TRUE)
@@ -124,5 +119,7 @@ the same SUs."
 
 	d$on_farm <- FALSE
 	d$is_survey <- TRUE
+	d$depth_range <- NULL
+	
 	carobiner::write_files(path, meta, d)
 }

--- a/scripts/soil_samples/doi_10.5281_zenodo.6566752.R
+++ b/scripts/soil_samples/doi_10.5281_zenodo.6566752.R
@@ -79,7 +79,8 @@ the same SUs."
 	d1 <- data.frame(
 		country = "Ethiopia",
 		adm1 = gsub("_", "-", r1$Region),
-		location_id = r1$FieldCode,
+		location_id = gsub(" +", "", trimws(r1$FieldCode)),
+		depth_range = depth_range,
 		longitude = r1$LAT, #swapped
 		latitude = r1$LON, #swapped
 		geo_from_source = TRUE,


### PR DESCRIPTION
d1 was missing the depth_range join key, so merge(d1, d2, by=c("location_id",
"depth_range")) errored. location_id was also unnormalized in d1 while d2/d3
stripped spaces, silently dropping valid texture/litter matches on ~12-15 rows.
Add depth_range and normalize location_id consistently across all three tables.