### PR TITLE
varieties_cowpea-functions error: yield_part wrongly assigned to yield when yield na

### DIFF
--- a/scripts/varieties_cowpea/_functions.R
+++ b/scripts/varieties_cowpea/_functions.R
@@ -263,6 +263,7 @@ process_cowpea <- function(ff) {
 	d$country[d$country == "Swaziland"] <- "Eswatini"
 	d$country[d$country == "Columbia"] <- "Colombia"
 
+	if (!"yield" %in% names(d)) d$yield <- NA_real_
 	d$yield[d$yield < 0] <- NA
 	d
 }


### PR DESCRIPTION
yield is not numeric in the compiled dataset

```
> bad_yield
                         dataset_id   crop yield_part  yield
                             <char> <char>     <char> <char>
   1: doi_10.25502_20180817_1124_BO cowpea       seed       
   2: doi_10.25502_20180817_1124_BO cowpea       seed       
   3: doi_10.25502_20180817_1124_BO cowpea       seed       
   4: doi_10.25502_20180817_1124_BO cowpea       seed       
   5: doi_10.25502_20180817_1124_BO cowpea       seed       
  ---                                                       
1418: doi_10.25502_20180921_1227_BO cowpea       seed       
1419: doi_10.25502_20180921_1227_BO cowpea       seed       
1420: doi_10.25502_20180921_1227_BO cowpea       seed       
1421: doi_10.25502_20180921_1227_BO cowpea       seed       
1422: doi_10.25502_20180921_1227_BO cowpea       seed   
```
